### PR TITLE
added Sentinel from jupyter_nbformat

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,3 @@
-.. image:: https://travis-ci.org/kynan/nbstripout.svg?branch=master
-    :target: https://travis-ci.org/kynan/nbstripout
-
 nbstripout: strip output from Jupyter and IPython notebooks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -47,18 +44,18 @@ Set up a git filter using nbstripout as follows: ::
     git config filter.nbstripout.clean '/path/to/nbstripout'
     git config filter.nbstripout.smudge cat
     git config filter.nbstripout.required true
+    
+You can use the ``--global`` flag to apply these settings to all repos.
 
 Create a file ``.gitattributes`` or ``.git/info/attributes`` with: ::
 
     *.ipynb filter=nbstripout
+    
+On Linux systems, you can create ``~/.config/git/attributes`` for a 
+user-level, site-wide gitattributes file.
 
-Mercurial usage
+Metadata
 ===============
 
-Mercurial does not have the equivalent of smudge filters.  One can use
-an encode/decode hook but this has some issues.  An alternative
-solution is to provide a set of commands that first run ``nbstripout``,
-then perform these operations. This is the approach of the `mmf-setup`_
-package.
-
-.. _mmf-setup: http://bitbucket.org/mforbes/mmf_setup
+This repo built on mforbes/nbstripout.
+README modified by dmhowcroft.

--- a/nbstripout.py
+++ b/nbstripout.py
@@ -70,6 +70,23 @@ except ImportError:
         def write(nb, f):
             return current.write(nb, f, 'json')
 
+        class Sentinel(object):
+
+            def __init__(self, name, module, docstring=None):
+                self.name = name
+                self.module = module
+                if docstring:
+                    self.__doc__ = docstring
+
+
+            def __repr__(self):
+                return str(self.module)+'.'+self.name
+
+        NO_CONVERT = Sentinel('NO_CONVERT', __name__,
+                              """Value to prevent nbformat to convert notebooks to most recent version.                                                                                                              
+                              """)
+
+
 
 def _cells(nb):
     """Yield all cells in an nbformat-insensitive manner"""


### PR DESCRIPTION
This supports older systems running IPython (without this change, we get a NameError because NO_CONVERT is not defined).

Sentinel is defined in: https://github.com/jupyter/nbformat/blob/616df84f257db4181b9eba2851d300cfb76ed90e/jupyter_nbformat/sentinel.py
